### PR TITLE
Fix: Misleading error for unrecognized behavior ports

### DIFF
--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -673,9 +673,9 @@ TreeNode::Ptr XMLParser::PImpl::createNodeFromXML(const XMLElement* element,
         auto port_model_it = manifest->ports.find(port_name);
         if(port_model_it == manifest->ports.end())
         {
-          throw RuntimeError(StrCat("a port with name [", port_name,
-                                    "] is found in the XML (<", element->Name(),
-                                    ">, line ", std::to_string(att->GetLineNum()),
+          throw RuntimeError(StrCat("A port with name [", port_name,
+                                    "] is found in the XML (", type_ID, ", line ",
+                                    std::to_string(element->GetLineNum()),
                                     ") but not in the providedPorts() of its "
                                     "registered node type."));
         }


### PR DESCRIPTION
## Summary
- Use `type_ID` instead of `element->Name()` so the error prints the actual behavior name (e.g., `ClearSnapshot`) rather than the generic XML tag (e.g., `Action`).
- Use `element->GetLineNum()` instead of `att->GetLineNum()` for a more accurate line number.

Fixes PickNikRobotics/moveit_pro#18029

**Before:**
```
a port with name [topic_name] is found in the XML (<Action>, line 6) but not in the providedPorts() of its registered node type.
```

**After:**
```
A port with name [topic_name] is found in the XML (ClearSnapshot, line 6) but not in the providedPorts() of its registered node type.
```

### Note on line numbers
Line numbers may not match the original XML file because MoveIt Pro's objective server reformats the XML through `tinyxml2::XMLPrinter` before passing it to BehaviorTree.CPP (see `load_objective_definitions.cpp`). The line numbers reported are relative to the reformatted XML, not the original file. Fixing this offset is out of scope for this PR — the behavior name is the more important improvement for debugging.

## Test plan
- [x] Build `behaviortree_cpp` in the MoveIt Pro container
- [x] Reproduce original bug by removing `providedPorts()` from `ClearSnapshot` and adding a `topic_name` port in the objective XML
- [x] Confirm the error now shows the correct behavior name

🤖 Generated with [Claude Code](https://claude.com/claude-code)