### PR TITLE
Handle empty vector toStr case

### DIFF
--- a/include/behaviortree_cpp/basic_types.h
+++ b/include/behaviortree_cpp/basic_types.h
@@ -281,6 +281,10 @@ template <typename T>
   {
     try
     {
+      if(value.empty())
+      {
+        return "";
+      }
       using InnerType = typename is_vector<T>::ValueType;
       std::stringstream ss;
       for(auto it = value.begin(); it != --value.end(); ++it)

--- a/tests/gtest_ports.cpp
+++ b/tests/gtest_ports.cpp
@@ -6,11 +6,26 @@
 
 using namespace BT;
 
-TEST(toStr, ConvertsVectors)
+TEST(toStr, ConvertsIntVector)
 {
   std::string val_str;
-  ASSERT_NO_THROW(val_str = BT::toStr(std::vector<int>{ 1, 2, 3, 4 }));
+  ASSERT_NO_THROW(val_str = toStr(std::vector<int>{ 1, 2, 3, 4 }));
   EXPECT_EQ(val_str, "1;2;3;4");
+}
+
+TEST(toStr, ConvertsStringVector)
+{
+  std::string val_str;
+  ASSERT_NO_THROW(val_str =
+                      toStr(std::vector<std::string>{ "hello", "", " ", "world", "!" }));
+  EXPECT_EQ(val_str, "hello;; ;world;!");
+}
+
+TEST(toStr, ConvertsEmptyVector)
+{
+  std::string val_str;
+  ASSERT_NO_THROW(val_str = toStr(std::vector<std::string>{}));
+  EXPECT_EQ(val_str, "");
 }
 
 class NodeWithPorts : public SyncActionNode


### PR DESCRIPTION
Didn't catch this until MoveIt Pro unit testing in https://github.com/PickNikRobotics/moveit_pro/pull/18537

