### PR TITLE
Make Blackboard::getKeys thread safe

### DIFF
--- a/include/behaviortree_cpp/blackboard.h
+++ b/include/behaviortree_cpp/blackboard.h
@@ -130,7 +130,7 @@ public:
 
   void debugMessage() const;
 
-  [[nodiscard]] std::vector<StringView> getKeys() const;
+  [[nodiscard]] std::vector<std::string> getKeys() const;
 
   [[deprecated("This command is unsafe. Consider using Backup/Restore instead")]] void
   clear();

--- a/src/blackboard.cpp
+++ b/src/blackboard.cpp
@@ -113,13 +113,14 @@ void Blackboard::debugMessage() const
   }
 }
 
-std::vector<StringView> Blackboard::getKeys() const
+std::vector<std::string> Blackboard::getKeys() const
 {
+  std::unique_lock<std::mutex> lock(mutex_);
   if(storage_.empty())
   {
     return {};
   }
-  std::vector<StringView> out;
+  std::vector<std::string> out;
   out.reserve(storage_.size());
   for(const auto& entry_it : storage_)
   {
@@ -272,10 +273,9 @@ std::shared_ptr<Blackboard::Entry> Blackboard::createEntryImpl(const std::string
 nlohmann::json ExportBlackboardToJSON(const Blackboard& blackboard)
 {
   nlohmann::json dest;
-  for(auto entry_name : blackboard.getKeys())
+  for(const std::string& name : blackboard.getKeys())
   {
-    std::string name(entry_name);
-    if(auto any_ref = blackboard.getAnyLocked(name))
+    if(AnyPtrLocked any_ref = blackboard.getAnyLocked(name))
     {
       if(auto any_ptr = any_ref.get())
       {

--- a/tests/gtest_blackboard.cpp
+++ b/tests/gtest_blackboard.cpp
@@ -558,9 +558,9 @@ TEST(BlackboardTest, BlackboardBackup)
   for(const auto& sub : tree.subtrees)
   {
     std::vector<std::string> keys;
-    for(const auto& str_view : sub->blackboard->getKeys())
+    for(const std::string& str : sub->blackboard->getKeys())
     {
-      keys.push_back(std::string(str_view));
+      keys.push_back(str);
     }
     expected_keys.push_back(keys);
   }


### PR DESCRIPTION
This is required for https://github.com/PickNikRobotics/moveit_pro/issues/18196.

I plan on holding pointers for serializing the blackboard, but this function is used in `ExportBlackboardToJSON` and so it needs to be resilient to blackboard variables being removed on the fly.