### PR TITLE
Rename package to behaviortree_cpp_picknik with versioned soname

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.3) # version on Ubuntu Focal
 
-project(behaviortree_cpp VERSION 4.7.2 LANGUAGES C CXX)
+project(behaviortree_cpp_picknik VERSION 4.7.2 LANGUAGES C CXX)
 
 # create compile_commands.json
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -188,7 +188,7 @@ target_link_libraries(${BTCPP_LIBRARY}
 target_include_directories(${BTCPP_LIBRARY}
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:include>
+        $<INSTALL_INTERFACE:${BTCPP_INCLUDE_DESTINATION}>
     PRIVATE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rdparty>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/lexy/include>
@@ -211,6 +211,15 @@ else()
 endif()
 
 add_library(BT::${BTCPP_LIBRARY} ALIAS ${BTCPP_LIBRARY})
+
+# A versioned soname (libbehaviortree_cpp_picknik.so.<major>.<minor>) makes a
+# binary built against one ABI fail loudly at load time instead of silently
+# binding to an incompatible library. Upstream ships an unversioned soname,
+# which is what made the nav2 ABI mismatch in moveit_pro#20928 silently
+# reachable. Minor-version bumps of this fork are treated as ABI breaks.
+set_target_properties(${BTCPP_LIBRARY} PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})
 
 # Add fuzzing targets
 if(ENABLE_FUZZING)

--- a/cmake/ament_build.cmake
+++ b/cmake/ament_build.cmake
@@ -24,7 +24,11 @@ set( BTCPP_EXTRA_LIBRARIES
 ament_export_dependencies(ament_index_cpp)
 
 set( BTCPP_LIB_DESTINATION     lib )
-set( BTCPP_INCLUDE_DESTINATION include )
+# Headers install under a package-scoped root so this fork can coexist with
+# upstream behaviortree_cpp on the same system (moveit_pro#20928). The exported
+# include dir below points consumers at the scoped root, so source code keeps
+# using #include "behaviortree_cpp/..." unchanged.
+set( BTCPP_INCLUDE_DESTINATION include/${PROJECT_NAME} )
 set( BTCPP_BIN_DESTINATION     bin )
 
 mark_as_advanced(
@@ -35,7 +39,7 @@ mark_as_advanced(
     BTCPP_BIN_DESTINATION )
 
 macro(export_btcpp_package)
-    ament_export_include_directories(include)
+    ament_export_include_directories(${BTCPP_INCLUDE_DESTINATION})
     ament_export_libraries(${BTCPP_LIBRARY})
     ament_export_targets(${BTCPP_LIBRARY}Targets)
     ament_package()

--- a/include/behaviortree_cpp/basic_types.h
+++ b/include/behaviortree_cpp/basic_types.h
@@ -1,5 +1,12 @@
 #pragma once
 
+// Marks these headers as the PickNik fork (behaviortree_cpp_picknik). Stock
+// upstream behaviortree_cpp coexists in the same image for nav2, and its
+// unscoped headers could win include resolution in a misconfigured build —
+// compiling fork consumers against the wrong ABI. Downstream code that
+// requires the fork checks this macro and fails the compile loudly instead.
+#define BTCPP_PICKNIK_FORK 1
+
 #include <algorithm>
 #include <cctype>
 #include <chrono>

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <package format="3">
-  <name>behaviortree_cpp</name>
+  <name>behaviortree_cpp_picknik</name>
   <version>4.7.2</version>
   <description>
   This package provides the Behavior Trees core library.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,10 +49,10 @@ else()
     find_package(GTest REQUIRED)
 
     enable_testing()
-    add_executable(behaviortree_cpp_test ${BT_TESTS})
-    add_test(NAME btcpp_test COMMAND behaviortree_cpp_test)
+    add_executable(${BTCPP_LIBRARY}_test ${BT_TESTS})
+    add_test(NAME btcpp_test COMMAND ${BTCPP_LIBRARY}_test)
 
-    target_link_libraries(behaviortree_cpp_test
+    target_link_libraries(${BTCPP_LIBRARY}_test
         GTest::gtest
         GTest::gtest_main
         GTest::gmock
@@ -60,6 +60,6 @@ else()
 
 endif()
 
-target_link_libraries(behaviortree_cpp_test ${BTCPP_LIBRARY} bt_sample_nodes foonathan::lexy)
-target_include_directories(behaviortree_cpp_test PRIVATE include ${PROJECT_SOURCE_DIR}/3rdparty)
-target_compile_definitions(behaviortree_cpp_test PRIVATE BT_TEST_FOLDER="${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(${BTCPP_LIBRARY}_test ${BTCPP_LIBRARY} bt_sample_nodes foonathan::lexy)
+target_include_directories(${BTCPP_LIBRARY}_test PRIVATE include ${PROJECT_SOURCE_DIR}/3rdparty)
+target_compile_definitions(${BTCPP_LIBRARY}_test PRIVATE BT_TEST_FOLDER="${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
[written by AI]

Implements the rename decided for [moveit_pro#20928](https://github.com/PickNikRobotics/moveit_pro/issues/20928) (decision record there; targets MoveIt Pro 10.0.0): this fork becomes `behaviortree_cpp_picknik` so stock upstream `behaviortree_cpp` can serve nav2 on the same system, ending the shared-name ABI collision that crashes `bt_navigator` on Jazzy.

## What changes

- `project()`/`package.xml` → `behaviortree_cpp_picknik`; library, ament package, CMake config, and exported targets all follow.
- **Versioned soname** (approved by Josh Whitley): `VERSION 4.7.2`, `SOVERSION 4.7` → `libbehaviortree_cpp_picknik.so.4.7`. Consumers stamp the versioned name into `DT_NEEDED`, so a future ABI-breaking rebase (e.g. the 4.9 merge, #17640 in moveit_pro) bumps the soname and stale binaries fail loudly at load instead of silently corrupting — the exact failure mode of moveit_pro#20928. Minor version bumps of this fork are treated as ABI breaks.
- **Headers install under a package-scoped root** (`include/behaviortree_cpp_picknik/behaviortree_cpp/...`), with the scoped root exported via `ament_export_include_directories` and `INSTALL_INTERFACE`. Consumers keep `#include "behaviortree_cpp/..."` unchanged, and the install no longer collides with stock's `include/behaviortree_cpp/`.
- `tests/CMakeLists.txt`: the shared tail hardcoded `behaviortree_cpp_test` while the ament branch derives `${BTCPP_LIBRARY}_test` — the names only coincided before the rename; unified on the variable.
- Non-ament (conan) build path is behavior-identical: it defines the same `BTCPP_INCLUDE_DESTINATION` (plain `include`), which the `INSTALL_INTERFACE` now references.

## Validation (ROS Jazzy container, colcon)

- Package builds clean under the new name; **full test suite: 208 tests, 0 failures**.
- Install layout verified: `libbehaviortree_cpp_picknik.so → .so.4.7 → .so.4.7.2`, `SONAME libbehaviortree_cpp_picknik.so.4.7` (readelf), scoped headers, `behaviortree_cpp_picknikConfig.cmake`.
- Consumer smoke test: separate CMake project, `find_package(behaviortree_cpp_picknik)` + `ament_target_dependencies`, source includes `behaviortree_cpp/bt_factory.h` **unchanged** — compiles, links, ticks a tree successfully, and `readelf -d` shows `NEEDED: libbehaviortree_cpp_picknik.so.4.7`.

## Notes / follow-ups

- The vendored lexy headers still install to unscoped `include/lexy` — no conflict with stock 4.9 (upstream removed lexy in 4.9), so left untouched to keep the diff minimal.
- After merge: apt_build_farm PR pins `packages/behaviortree_cpp/package.json` to the merged SHA with the renamed package (tracked under moveit_pro#20928), then the moveit_pro consumption switch (`find_package` in ~6 packages, Dockerfile unpin of stock, mixed-loading CI guard).
