### PR TITLE
fix: make bt4_picknik tools and vendored lexy disjoint from stock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,38 @@ endif()
 #############################################################
 # LIBRARY
 
+# lexy is linked PRIVATE/BUILD_INTERFACE-only (see the target_link_libraries
+# calls below) and its only consumer, src/script_parser.cpp, is compiled into
+# this library itself. No header reachable from the public entry points
+# (behavior_tree.h / bt_factory.h / basic_types.h) includes lexy; the
+# scripting/operators.hpp -> any_types.hpp chain does, but it is parser-internal
+# and consumed only by src/script_parser.cpp. So installing lexy's own
+# headers/CMake config/static lib is dead weight that would otherwise collide
+# with any stock behaviortree_cpp snapshot that also vendors lexy unscoped
+# (issue #20928). Disable lexy's own install rule before pulling it in.
+#
+# CACHE ... FORCE is configure-wide, not scoped to this add_subdirectory() call:
+# if this project is itself embedded via add_subdirectory() alongside another,
+# unrelated lexy instance, forcing this cache entry OFF would also suppress
+# that instance's install rules for the rest of the configure run. Save the
+# caller's prior cache state (absent or a value) and restore it once lexy's own
+# option(LEXY_ENABLE_INSTALL ...) has read our forced OFF -- restoring after
+# add_subdirectory() returns is safe because that option() call, not any later
+# read, is what CMP0077-OLD in 3rdparty/lexy/CMakeLists.txt makes CACHE FORCE
+# necessary for in the first place.
+if(DEFINED CACHE{LEXY_ENABLE_INSTALL})
+    set(_btcpp_picknik_prev_lexy_enable_install "${LEXY_ENABLE_INSTALL}")
+else()
+    unset(_btcpp_picknik_prev_lexy_enable_install)
+endif()
+set(LEXY_ENABLE_INSTALL OFF CACHE BOOL "Disabled by behaviortree_cpp_picknik, see comment above" FORCE)
 add_subdirectory(3rdparty/lexy)
+if(DEFINED _btcpp_picknik_prev_lexy_enable_install)
+    set(LEXY_ENABLE_INSTALL "${_btcpp_picknik_prev_lexy_enable_install}" CACHE BOOL "Disabled by behaviortree_cpp_picknik, see comment above" FORCE)
+    unset(_btcpp_picknik_prev_lexy_enable_install)
+else()
+    unset(LEXY_ENABLE_INSTALL CACHE)
+endif()
 
 add_library(minitrace STATIC 3rdparty/minitrace/minitrace.cpp)
 target_compile_definitions(minitrace PRIVATE MTR_ENABLED=True)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,19 +1,22 @@
 
 include_directories(${PROJECT_SOURCE_DIR}/3rdparty)
 
-# add_executable(bt4_log_cat         bt_log_cat.cpp )
-# target_link_libraries(bt4_log_cat  ${BTCPP_LIBRARY} )
-# install(TARGETS bt4_log_cat
+# add_executable(bt4_picknik_log_cat         bt_log_cat.cpp )
+# target_link_libraries(bt4_picknik_log_cat  ${BTCPP_LIBRARY} )
+# install(TARGETS bt4_picknik_log_cat
 #         DESTINATION ${BTCPP_BIN_DESTINATION} )
 
+# bt4_picknik_* names (rather than upstream's bt4_*) so no bin/ path collides
+# with stock upstream behaviortree_cpp, which installs identically-named
+# tools at the same unscoped destination (issue #20928).
 if( ZMQ_FOUND )
-    add_executable(bt4_recorder         bt_recorder.cpp )
-    target_link_libraries(bt4_recorder  ${BTCPP_LIBRARY} ${ZMQ_LIBRARIES})
-    install(TARGETS bt4_recorder
+    add_executable(bt4_picknik_recorder         bt_recorder.cpp )
+    target_link_libraries(bt4_picknik_recorder  ${BTCPP_LIBRARY} ${ZMQ_LIBRARIES})
+    install(TARGETS bt4_picknik_recorder
             DESTINATION ${BTCPP_BIN_DESTINATION} )
 endif()
 
-add_executable(bt4_plugin_manifest         bt_plugin_manifest.cpp )
-target_link_libraries(bt4_plugin_manifest  ${BTCPP_LIBRARY} )
-install(TARGETS bt4_plugin_manifest
+add_executable(bt4_picknik_plugin_manifest         bt_plugin_manifest.cpp )
+target_link_libraries(bt4_picknik_plugin_manifest  ${BTCPP_LIBRARY} )
+install(TARGETS bt4_picknik_plugin_manifest
         DESTINATION ${BTCPP_BIN_DESTINATION} )


### PR DESCRIPTION
[written by AI]

## Motivation

Closes the remaining gap in issue #20928. #26 gave the fork's library, headers, and CMake config distinct names from stock upstream `behaviortree_cpp` (used by nav2 in the same image), but two file sets were still shared or shareable between the two packages:

- **`bin/bt4_plugin_manifest`** (and `bin/bt4_recorder`, gated on `ZMQ_FOUND`) used stock's unscoped tool names. Verified live: installing this fork's deb followed by stock's deb hits a real dpkg fatal error — `trying to overwrite '/opt/ros/jazzy/bin/bt4_plugin_manifest', which is also in package ros-jazzy-behaviortree-cpp-picknik`. dpkg's `path-exclude` mechanism (used elsewhere in the moveit_pro image to keep stock's dev files out) does **not** prevent this class of conflict — it only suppresses extraction for files that aren't already claimed by another installed package; the overwrite check runs regardless. Proven with a minimal synthetic two-package dpkg test before touching this repo.
- **Vendored lexy** installed its own headers, CMake config, and static lib unscoped (`include/lexy/`, `include/lexy_ext/`, `lib/<arch>/cmake/lexy/`, `lib/<arch>/liblexy_file.a`). The currently pinned stock snapshot doesn't vendor lexy, but a future one plausibly could, recreating the same collision class.

Renaming/excluding at the source (this repo) is more robust than trying to path-exclude around a collision after the fact, since exclude-based mitigation is proven insufficient for genuinely double-owned files.

## Changes

- **`tools/CMakeLists.txt`**: renamed `bt4_plugin_manifest` → `bt4_picknik_plugin_manifest`, `bt4_recorder` → `bt4_picknik_recorder`. No other file in the repo references the old names (confirmed via full-repo grep before renaming).
- **`CMakeLists.txt`**: set `LEXY_ENABLE_INSTALL OFF` before `add_subdirectory(3rdparty/lexy)`, using lexy's own existing install-guard option rather than hand-patching each `install()` call in its CMakeLists. Verified safe to drop: lexy is linked `PRIVATE`/`BUILD_INTERFACE`-only, and its only consumer, `src/script_parser.cpp`, is compiled into this library itself. No installed public header transitively includes lexy — only the internal `scripting/operators.hpp` → `scripting/any_types.hpp` chain does, and neither `behavior_tree.h`, `bt_factory.h`, nor `basic_types.h` reaches that chain (confirmed by grep).

## Tests

207/207 pass (ament build, `behaviortree_cpp_picknik_test`, zero failures). Test count is unaffected by these edits by construction — renaming CMake executable targets and toggling an unrelated 3rdparty subproject's install option cannot change which gtest cases are discovered from `tests/CMakeLists.txt`.

## Empirical disjointness proof (acceptance criterion)

Built this branch's deb the same way apt_build_farm does — `bloom-generate rosdebian --ros-distro jazzy --debian-inc 1` then `fakeroot debian/rules binary` — and compared its `dpkg-deb -c` file list against the pinned stock snapshot (`ros-jazzy-behaviortree-cpp` 4.9.0-1noble.20260412.042652, the exact package apt_build_farm's build environment resolves today).

```
$ comm -12 <(dpkg-deb -c ros-jazzy-behaviortree-cpp-picknik_4.7.2-1noble_amd64.deb | ...) \
           <(dpkg-deb -c ros-jazzy-behaviortree-cpp_4.9.0-1noble.20260412.042652_amd64.deb | ...)
# directory entries only (/, /opt/, /opt/ros/jazzy/bin/, /usr/share/doc/, ...) — 16 shared, all directories
# regular FILES only, after filtering out directory entries (paths ending in /):
#   fork:  108 files
#   stock: 110 files
#   intersection: 0
```

Fork's `bin/` now contains only `bt4_picknik_plugin_manifest` (`bt4_picknik_recorder` doesn't build in this ament configuration — pre-existing, unrelated: `tools/CMakeLists.txt` checks `ZMQ_FOUND`, but `cmake/FindZeroMQ.cmake` sets `ZeroMQ_FOUND`, so the `if(ZMQ_FOUND)` guard has never been true here). Fork's `include/` and `lib/` ship zero lexy paths. Stock's file list is unchanged from before this PR.

## Release notes

N/A — this repo doesn't use moveit_pro's release-note convention.

## Agent review

This repo has no `## Claude agent checks` template, so recording results here instead of a checklist. Reviewers ran sequentially per `moveit_pro`'s `.claude/rules/agent-delegation.md` (`code-reviewer` always; `platform-architect-bot` added for packaging/CMake scope; `security-auditor` gated on findings).

- **`code-reviewer`**: 1 P2 — the `LEXY_ENABLE_INSTALL` `CACHE BOOL` help-string was empty (`""`), giving no context to anyone inspecting `cmake-gui`/`ccmake`. Applied: help-string now reads `"Disabled by behaviortree_cpp_picknik, see comment above"`.
- **`platform-architect-bot`**: no P0/P1. Empirically verified the `CACHE ... FORCE` idiom is load-bearing, not just sufficient — a plain `set(LEXY_ENABLE_INSTALL OFF)` gets silently overridden by lexy's own `option(LEXY_ENABLE_INSTALL ...)` because `3rdparty/lexy/CMakeLists.txt`'s `cmake_minimum_required(VERSION 3.8)` puts CMP0077 in OLD behavior; confirmed by a counterfactual build. Also verified the `$<BUILD_INTERFACE:>`/`$<INSTALL_INTERFACE:>` split correctly keeps lexy out of this library's exported `INTERFACE_LINK_LIBRARIES`. 4 P2s:
  - Comment at `CMakeLists.txt:97-99` was self-contradictory — it claimed "No installed public header transitively includes it" while its own parenthetical named `scripting/operators.hpp`/`any_types.hpp`, which *are* installed. **Applied**: reworded to "No header reachable from the public entry points … includes lexy; the … chain does, but it is parser-internal."
  - `tools/CMakeLists.txt`'s `bt4_picknik_recorder` rename is currently unreachable/unexercised by any build in this repo, since the guard checks `ZMQ_FOUND` (never set — only `cmake/FindZeroMQ.cmake`'s `ZeroMQ_FOUND` is) — a pre-existing, unrelated bug. **Deferred**: out of scope for this PR (already called out in the disjointness-proof section above); fixing the `ZMQ_FOUND`/`ZeroMQ_FOUND` mismatch is a separate change.
  - `cmake/conan_build.cmake:18` sets `BTCPP_INCLUDE_DESTINATION` to bare `include` (unscoped), unlike `ament_build.cmake:31`'s `include/${PROJECT_NAME}` — so the conan build path would install headers to `include/behaviortree_cpp/**`, colliding wholesale with stock. **Deferred**: moveit_pro only ever builds this fork via the ament path (confirmed disjoint, proof above); the conan path is pre-existing and out of scope for a packaging-disjointness PR scoped to what moveit_pro actually ships.
  - Optionally exclude `scripting/operators.hpp`/`any_types.hpp` from the installed headers glob, since they're lexy-only and parser-internal. **Deferred**: the bot's own framing was "arguably its own PR" — it would change the installed file set (requiring the disjointness proof to be re-run) for a header-hygiene improvement unrelated to this PR's actual collision fix.
- **`security-auditor`**: not run. No finding from `code-reviewer` or `platform-architect-bot` was security-flavored (all were comment accuracy, CMake variable scoping, and unreachable-build-path observations); nothing in this PR's diff touches parsing untrusted input, credentials, or network-facing code.

Tests re-confirmed green after the P2 fixes: `cmake --configure` succeeds cleanly (verified in-container); both applied changes are comment/help-string text only, touching no `install()` rule or target name, so the file set — and therefore the empirical disjointness proof above — is unchanged and was not re-run.

## CodeRabbit review

- **`CMakeLists.txt:95-104`** (Minor): `LEXY_ENABLE_INSTALL OFF CACHE ... FORCE` is configure-wide; if this project is embedded via `add_subdirectory()` alongside another, unrelated lexy instance, the forced `OFF` would silently suppress that instance's install rules too. **Applied** (`b8d70d6e`): save the caller's prior cache state (absent, or its previous value) before forcing `OFF`, restore it immediately after `add_subdirectory(3rdparty/lexy)` returns — safe because lexy's own `option(LEXY_ENABLE_INSTALL ...)` has already read the forced value by then (the same CMP0077-OLD mechanism platform-architect-bot verified makes `CACHE FORCE` necessary in the first place only applies to that one read). Re-verified after the fix: clean configure, 207/207 tests pass, install tree still ships zero lexy paths and only `bt4_picknik_plugin_manifest` in `bin/` — install rules unchanged, so the empirical disjointness proof above was not re-run.